### PR TITLE
Fix: Persist ExpandableText state across recomposition

### DIFF
--- a/app/src/main/java/com/pira/ccloud/components/ExpandableTextComponent.kt
+++ b/app/src/main/java/com/pira/ccloud/components/ExpandableTextComponent.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
@@ -18,9 +17,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.zIndex
 
@@ -30,9 +29,9 @@ fun ExpandableText(
     modifier: Modifier = Modifier,
     collapsedMaxLines: Int = 2
 ) {
-    var expanded by remember { mutableStateOf(false) }
-    var showReadMore by remember { mutableStateOf(false) }
-    
+    var expanded by rememberSaveable { mutableStateOf(false) }
+    var showReadMore by rememberSaveable { mutableStateOf(false) }
+
     Column(modifier = modifier) {
         Text(
             text = text,


### PR DESCRIPTION
**Problem**
When users scrolled through the series list and returned to top of the screen, the text would collapse back to its truncated state. This occurred because `ExpandableText` was using remember instead of `rememberSaveable`, causing state to be lost when items left and re-entered the composition during list scrolling.

**Changes**
1. Changed `expanded` from remember to `rememberSaveable`
2. Changed `showReadMore` from remember to `rememberSaveable`

**Result**
Text expansion state now persists during list scrolling and configuration changes.


https://github.com/user-attachments/assets/cf548e30-8bec-4227-bf31-5f949b53c96a


